### PR TITLE
fix: ensure package cache is up to date by using specific ansible modules

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/JonasPammer/cookiecutter-ansible-role",
-  "commit": "6f4489e5dc92ed120a738aa12e33339fc801bc30",
+  "commit": "b112717022c8acd16139f6d17108c451d6e8822f",
   "context": {
     "cookiecutter": {
       "full_name": "Jonas Pammer",

--- a/README.adoc
+++ b/README.adoc
@@ -62,9 +62,10 @@ include::meta/main.yml[]
 [[requirements]]
 == 📌 Requirements
 // Any prerequisites that may not be covered by this role or Ansible itself should be mentioned here.
-User needs to be able to `become`
+The Ansible User needs to be able to `become`.
 
-
+The https://galaxy.ansible.com/community/general[`community.general` collection]
+must be installed on the Ansible controller.
 
 [[variables]]
 == 📜 Role Variables

--- a/requirements.yml
+++ b/requirements.yml
@@ -1,3 +1,4 @@
 ---
 collections:
-  - name: community.docker
+  - name: community.docker # only needed for molecule execution
+  - name: community.general

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,10 +61,53 @@
     - name: gather ansible facts
       ansible.builtin.setup:
 
-    - name: install bootstrap packages (package)
-      ansible.builtin.package:
-        name: "{{ item }}"
-        state: present
-      loop: "{{ bootstrap_facts_packages.split() }}"
+    - name: update cache and install bootstrap packages (apt)
+      ansible.builtin.apt:
+        name: "{{ bootstrap_facts_packages.split() }}"
+        update_cache: true
+      changed_when: false
+      when: ansible_pkg_mgr == "apt"
+
+    - name: update cache and install bootstrap packages (yum)
+      ansible.builtin.yum:
+        name: "{{ bootstrap_facts_packages.split() }}"
+        update_cache: true
+      changed_when: false
+      when: ansible_pkg_mgr == "yum"
+
+    - name: update cache and install bootstrap packages (apk)
+      community.general.apk:
+        name: "{{ bootstrap_facts_packages.split() }}"
+        update_cache: true
+      changed_when: false
+      when: ansible_pkg_mgr == "apk"
+
+    - name: update cache and install bootstrap packages (dnf)
+      ansible.builtin.dnf:
+        name: "{{ bootstrap_facts_packages.split() }}"
+        update_cache: true
+      changed_when: false
+      when: ansible_pkg_mgr == "dnf"
+
+    - name: update cache and install bootstrap packages (zypper)
+      community.general.zypper:
+        name: "{{ bootstrap_facts_packages.split() }}"
+        update_cache: true
+      changed_when: false
+      when: ansible_pkg_mgr == "zypper"
+
+    - name: update cache and install bootstrap packages (pacman)
+      community.general.pacman:
+        name: "{{ bootstrap_facts_packages.split() }}"
+        update_cache: true
+      changed_when: false
+      when: ansible_pkg_mgr == "pacman"
+
+    - name: update cache and install bootstrap packages (portage)
+      community.general.portage:
+        package: "{{ bootstrap_facts_packages.split() }}"
+        sync: true
+      changed_when: false
+      when: ansible_pkg_mgr == "portage"
   become: true
   become_user: "{{ bootstrap_ansible_user | default(bootstrap_user) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,49 +61,49 @@
     - name: gather ansible facts
       ansible.builtin.setup:
 
-    - name: update cache and install bootstrap packages (apt)
+    - name: Update cache and install bootstrap packages (apt).
       ansible.builtin.apt:
         name: "{{ bootstrap_facts_packages.split() }}"
         update_cache: true
       changed_when: false
       when: ansible_pkg_mgr == "apt"
 
-    - name: update cache and install bootstrap packages (yum)
+    - name: Update cache and install bootstrap packages (yum).
       ansible.builtin.yum:
         name: "{{ bootstrap_facts_packages.split() }}"
         update_cache: true
       changed_when: false
       when: ansible_pkg_mgr == "yum"
 
-    - name: update cache and install bootstrap packages (apk)
+    - name: Update cache and install bootstrap packages (apk).
       community.general.apk:
         name: "{{ bootstrap_facts_packages.split() }}"
         update_cache: true
       changed_when: false
       when: ansible_pkg_mgr == "apk"
 
-    - name: update cache and install bootstrap packages (dnf)
+    - name: Update cache and install bootstrap packages (dnf).
       ansible.builtin.dnf:
         name: "{{ bootstrap_facts_packages.split() }}"
         update_cache: true
       changed_when: false
       when: ansible_pkg_mgr == "dnf"
 
-    - name: update cache and install bootstrap packages (zypper)
+    - name: Update cache and install bootstrap packages (zypper).
       community.general.zypper:
         name: "{{ bootstrap_facts_packages.split() }}"
         update_cache: true
       changed_when: false
       when: ansible_pkg_mgr == "zypper"
 
-    - name: update cache and install bootstrap packages (pacman)
+    - name: Update cache and install bootstrap packages (pacman).
       community.general.pacman:
         name: "{{ bootstrap_facts_packages.split() }}"
         update_cache: true
       changed_when: false
       when: ansible_pkg_mgr == "pacman"
 
-    - name: update cache and install bootstrap packages (portage)
+    - name: Update cache and install bootstrap packages (portage).
       community.general.portage:
         package: "{{ bootstrap_facts_packages.split() }}"
         sync: true


### PR DESCRIPTION
Fixes #37 

the raw commands also update the cache. but using ansible modules if available seems to be the better thing do to

## **Required Checklist**

- [x] documentation has been altered or extended appropriately
- [x] this pull request and its commits address only a single concern
- [x] i am a nice guy <!-- FYI, that's the TL;DR of the CODE_OF_CONDUCT.md -->

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Yes! It adds `community.general` as a dependency of the role.

## _Optional_ Checklist

- [x] pre-commit was installed in local development environment (if not, a GitHub workflow will run pre-commit once you create the request)

- [x] my commits are small, single-purpose, detailed and maybe even follow the [conventional commit specification](https://gist.github.com/JonasPammer/4ea577854ae10afe644bff366d7b2a8a) for extra convenience of the reviewer
