### PR TITLE
refactor: always issue our own raw commands

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -63,9 +63,6 @@ include::meta/main.yml[]
 // Any prerequisites that may not be covered by this role or Ansible itself should be mentioned here.
 The Ansible User needs to be able to `become`.
 
-The https://galaxy.ansible.com/community/general[`community.general` collection]
-must be installed on the Ansible controller.
-
 [[variables]]
 == 📜 Role Variables
 // A description of the settable variables for this role should go here

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,7 @@
   rescue:
     - name: "NOTE - wait_for_connection failed for hosts listed in this Task"
       debug: var=bootstrap_timeout
+      changed_when: true
   always:
     - name: include tasks to gather bootstrap facts (raw)
       ansible.builtin.include_tasks:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -26,9 +26,9 @@
       register: bootstrap_connect
       changed_when: false
   rescue:
-    - name: "NOTE - wait_for_connection failed for hosts listed in this Task. Trying to bootstrap them using ansible's raw module.."
+    - name: "NOTE - wait_for_connection failed for hosts listed in this Task"
       debug: var=bootstrap_timeout
-
+  always:
     - name: include tasks to gather bootstrap facts (raw)
       ansible.builtin.include_tasks:
         file: gather_facts.yml
@@ -43,7 +43,7 @@
           bootstrap_os_family in [ "Debian", "RedHat", "Rocky", "Suse" ])
       vars:
         ansible_user: "{{ bootstrap_user }}"
-  always:
+
     - name: set 'bootstrap_ansible_user' to value of 'ansible_user' (when wait_for_connection succeeded)
       ansible.builtin.set_fact:
         bootstrap_ansible_user: "{{ ansible_user }}"
@@ -57,58 +57,16 @@
       when:
         - bootstrap_connect is failed
 
-- name: ensure system is prepared by issuing ansible modules.
+- name: ensure system is prepared by issuing ansible modules as bootstrap_ansible_user.
   block:
-    - name: gather ansible facts
+    - name: Gather ansible facts.
       ansible.builtin.setup:
 
-    - name: Update cache and install bootstrap packages (apt).
-      ansible.builtin.apt:
-        name: "{{ bootstrap_facts_packages.split() }}"
+    - name: Install bootstrap packages (package).
+      ansible.builtin.package:
+        name: "{{ item }}"
+        state: present
         update_cache: true
-      changed_when: false
-      when: ansible_pkg_mgr == "apt"
-
-    - name: Update cache and install bootstrap packages (yum).
-      ansible.builtin.yum:
-        name: "{{ bootstrap_facts_packages.split() }}"
-        update_cache: true
-      changed_when: false
-      when: ansible_pkg_mgr == "yum"
-
-    - name: Update cache and install bootstrap packages (apk).
-      community.general.apk:
-        name: "{{ bootstrap_facts_packages.split() }}"
-        update_cache: true
-      changed_when: false
-      when: ansible_pkg_mgr == "apk"
-
-    - name: Update cache and install bootstrap packages (dnf).
-      ansible.builtin.dnf:
-        name: "{{ bootstrap_facts_packages.split() }}"
-        update_cache: true
-      changed_when: false
-      when: ansible_pkg_mgr == "dnf"
-
-    - name: Update cache and install bootstrap packages (zypper).
-      community.general.zypper:
-        name: "{{ bootstrap_facts_packages.split() }}"
-        update_cache: true
-      changed_when: false
-      when: ansible_pkg_mgr == "zypper"
-
-    - name: Update cache and install bootstrap packages (pacman).
-      community.general.pacman:
-        name: "{{ bootstrap_facts_packages.split() }}"
-        update_cache: true
-      changed_when: false
-      when: ansible_pkg_mgr == "pacman"
-
-    - name: Update cache and install bootstrap packages (portage).
-      community.general.portage:
-        package: "{{ bootstrap_facts_packages.split() }}"
-        sync: true
-      changed_when: false
-      when: ansible_pkg_mgr == "portage"
+      loop: "{{ bootstrap_facts_packages.split() }}"
   become: true
   become_user: "{{ bootstrap_ansible_user | default(bootstrap_user) }}"


### PR DESCRIPTION
removes much boilerplate

removes community.general dependency

Fixes #37 

<!-- Insert Description here, if any. -->

## **Required Checklist**

- [ ] Documentation has been altered or extended appropriately
- [x] This pull request and its commits address only a single concern
- [x] I have followed [JonasPammer's Ansible Role Development Guidelines](https://github.com/JonasPammer/cookiecutter-ansible-role/blob/master/ROLE_DEVELOPMENT_GUIDELINES.adoc)
- [x] I am a nice guy <!-- the 'too long; did not read;' of the CODE_OF_CONDUCT.md -->

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

## _Optional_ Checklist

- [ ] pre-commit was installed in local development environment (if not, a GitHub workflow will run pre-commit once you create the request)

- [ ] my commits are small, single-purpose, detailed and maybe even follow the [conventional commit specification](https://gist.github.com/JonasPammer/4ea577854ae10afe644bff366d7b2a8a) for extra convenience of the reviewer
