### PR TITLE
refactor!: drop support for ansible-core 2.9 and 2.10 (EOL)

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -1,4 +1,4 @@
 ---
+# list all collections used here (even if included in `ansible`)
 collections:
-  - name: community.docker # only needed for molecule execution
   - name: community.general

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,6 @@ parallel_show_output = True
 deps =
     4: ansible == 4.* # core 2.11 + https://github.com/ansible-community/ansible-build-data/blob/main/4/ansible-4.build
     5: ansible == 5.* # core 2.12 + https://github.com/ansible-community/ansible-build-data/blob/main/5/ansible-5.build
-    6: ansible == 6.* # core 2.13 + https://github.com/ansible-community/ansible-build-data/blob/main/6/ansible-6.build
     molecule[docker]
     docker == 5.*
     ansible-lint == 5.*

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ extend-ignore = E203
 ### Ansible Testing through Molecule ###
 [tox]
 minversion = 3.21.4
-envlist = pre-commit,py{3}-ansible-{4,5,6}
+envlist = pre-commit,py{3}-ansible-{4,5}
 
 skipsdist = true
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ extend-ignore = E203
 ### Ansible Testing through Molecule ###
 [tox]
 minversion = 3.21.4
-envlist = pre-commit,py{3}-ansible-{2.9,2.10,2.11,2.12}
+envlist = pre-commit,py{3}-ansible-{4,5,6}
 
 skipsdist = true
 
@@ -15,12 +15,12 @@ skipsdist = true
 passenv = *
 parallel_show_output = True
 deps =
-    2.9: ansible == 2.9.*
-    2.10: ansible-base == 2.10.*
-    2.11: ansible-core == 2.11.*
-    2.12: ansible-core == 2.12.*
+    4: ansible == 4.* # core 2.11
+    5: ansible == 5.* # core 2.12
+    6: ansible == 6.* # core 2.13
     molecule[docker]
-    docker == 4.*
+    docker == 5.*
+    ansible-lint == 5.*
 commands =
     ansible --version
     molecule destroy

--- a/tox.ini
+++ b/tox.ini
@@ -15,9 +15,9 @@ skipsdist = true
 passenv = *
 parallel_show_output = True
 deps =
-    4: ansible == 4.* # core 2.11
-    5: ansible == 5.* # core 2.12
-    6: ansible == 6.* # core 2.13
+    4: ansible == 4.* # core 2.11 + https://github.com/ansible-community/ansible-build-data/blob/main/4/ansible-4.build
+    5: ansible == 5.* # core 2.12 + https://github.com/ansible-community/ansible-build-data/blob/main/5/ansible-5.build
+    6: ansible == 6.* # core 2.13 + https://github.com/ansible-community/ansible-build-data/blob/main/6/ansible-6.build
     molecule[docker]
     docker == 5.*
     ansible-lint == 5.*


### PR DESCRIPTION
Fixes https://github.com/JonasPammer/cookiecutter-ansible-role/issues/11

most relevant and informatively correct read: https://www.ansible.com/blog/ansible-3.0.0-qa

## **Required Checklist**

- [ ] Documentation has been altered or extended appropriately
- [x] This pull request and its commits address only a single concern
- [x] I have followed [JonasPammer's Ansible Role Development Guidelines](https://github.com/JonasPammer/cookiecutter-ansible-role/blob/master/ROLE_DEVELOPMENT_GUIDELINES.adoc)
- [x] I am a nice guy <!-- the 'too long; did not read;' of the CODE_OF_CONDUCT.md -->

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

No, although upcoming PRs (that adapt to the tips as per the changelog ([e.g.](https://github.com/ansible-collections/community.general/blob/stable-5/CHANGELOG.rst)) will.

## _Optional_ Checklist

- [ ] pre-commit was installed in local development environment (if not, a GitHub workflow will run pre-commit once you create the request)

- [x] my commits are small, single-purpose, detailed and maybe even follow the [conventional commit specification](https://gist.github.com/JonasPammer/4ea577854ae10afe644bff366d7b2a8a) for extra convenience of the reviewer
