### PR TITLE
ci: add workflow dispatch option for defining ansible version for debug tox run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,6 +25,16 @@ permissions: read-all
           - ubuntu1604
           - ubuntu1804
           - ubuntu2004
+      ansible_version:
+        description: "Select Ansible Versions to run"
+        required: false
+        type: choice
+        default: "ansible-5,ansible-4"
+        options:
+          - ansible-5,ansible-4
+          - ansible-4,ansible-5
+          - ansible-4
+          - ansible-5
   pull_request:
   push:
     branches:
@@ -138,6 +148,7 @@ jobs:
       - name: Run Molecule tests (debug).
         run: tox
         env:
+          TOX_ENV: py3-${{ github.event.inputs.ansible }}
           TOX_SKIP_ENV: pre-commit
           MOLECULE_DESTROY: never
           MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Run Molecule tests (debug).
         run: tox
         env:
-          TOX_ENV: py3-${{ github.event.inputs.ansible }}
+          TOX_ENV: py3-${{ github.event.inputs.ansible_version }}
           TOX_SKIP_ENV: pre-commit
           MOLECULE_DESTROY: never
           MOLECULE_DISTRO: ${{ matrix.distro }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Run Molecule tests (debug).
         run: tox
         env:
-          TOX_ENV: py3-${{ github.event.inputs.ansible_version }}
+          TOXENV: py3-${{ github.event.inputs.ansible_version }}
           TOX_SKIP_ENV: pre-commit
           MOLECULE_DESTROY: never
           MOLECULE_DISTRO: ${{ matrix.distro }}


### PR DESCRIPTION
POC for https://github.com/JonasPammer/cookiecutter-ansible-role/issues/21

## **Required Checklist**

- [ ] Documentation has been altered or extended appropriately
- [x] This pull request and its commits address only a single concern
- [x] I have followed [JonasPammer's Ansible Role Development Guidelines](https://github.com/JonasPammer/cookiecutter-ansible-role/blob/master/ROLE_DEVELOPMENT_GUIDELINES.adoc)
- [x] I am a nice guy <!-- the 'too long; did not read;' of the CODE_OF_CONDUCT.md -->

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

## _Optional_ Checklist

- [x] pre-commit was installed in local development environment (if not, a GitHub workflow will run pre-commit once you create the request)

- [x] my commits are small, single-purpose, detailed and maybe even follow the [conventional commit specification](https://github.com/JonasPammer/JonasPammer/blob/master/demystifying/conventional_commits.adoc) for extra convenience of the reviewer
