### PR TITLE
feat!: set become to false by default, add ability to define become_user seperately from ansible_user

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -86,7 +86,20 @@ The Ansible User needs to be able to `become`.
 ----
 bootstrap_user: root
 ----
-Username used to connect to the machine.
+Username used to connect to the machine for the raw installation command task.
+
+[source,yaml]
+----
+bootstrap_become: false
+bootstrap_become_user: "{{ bootstrap_user }}"
+----
+`become` and `become_user` variables passed to most actual tasks.
+
+The default values cover the 99.9% use case.
+
+The default variable of `bootstrap_become` is false as
+`sudo` is not available before bootstrapping out-of-the-box
+more often than it is.
 
 [source,yaml]
 ----

--- a/README.orig.adoc
+++ b/README.orig.adoc
@@ -62,7 +62,20 @@ The Ansible User needs to be able to `become`.
 ----
 bootstrap_user: root
 ----
-Username used to connect to the machine.
+Username used to connect to the machine for the raw installation command task.
+
+[source,yaml]
+----
+bootstrap_become: false
+bootstrap_become_user: "{{ bootstrap_user }}"
+----
+`become` and `become_user` variables passed to most actual tasks.
+
+The default values cover the 99.9% use case.
+
+The default variable of `bootstrap_become` is false as 
+`sudo` is not available before bootstrapping out-of-the-box
+more often than it is.
 
 [source,yaml]
 ----

--- a/README.orig.adoc
+++ b/README.orig.adoc
@@ -73,7 +73,7 @@ bootstrap_become_user: "{{ bootstrap_user }}"
 
 The default values cover the 99.9% use case.
 
-The default variable of `bootstrap_become` is false as 
+The default variable of `bootstrap_become` is false as
 `sudo` is not available before bootstrapping out-of-the-box
 more often than it is.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,9 @@
 # defaults file of ansible-role jonaspammer.bootstrap
 # See README.adoc for documentation. If you change a default here, also update it in the README.
 
-bootstrap_become: false
 bootstrap_user: root
+bootstrap_become: false
+bootstrap_become_user: "{{ bootstrap_user }}"
 
 bootstrap_wait_for_host: false
 bootstrap_timeout: 3

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,8 @@
 # defaults file of ansible-role jonaspammer.bootstrap
 # See README.adoc for documentation. If you change a default here, also update it in the README.
 
+bootstrap_become: false
 bootstrap_user: root
+
 bootstrap_wait_for_host: false
 bootstrap_timeout: 3

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,7 +1,7 @@
 ---
 - name: Converge
   hosts: all
-  become: no
+  become: false
   gather_facts: false
 
   roles:

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -1,6 +1,7 @@
 ---
 - name: Converge
   hosts: all
+  become: no
   gather_facts: false
 
   roles:

--- a/tasks/gather_facts.yml
+++ b/tasks/gather_facts.yml
@@ -1,8 +1,8 @@
 ---
 - name: lookup bootstrap facts (raw).
-  become: false
   ansible.builtin.raw: "cat /etc/os-release"
   check_mode: false
+  become: false
   register: bootstrap_facts
   changed_when: false
   vars:
@@ -19,6 +19,8 @@
     - bootstrap_facts.rc == 0
     - bootstrap_distribution is not defined
     - bootstrap_facts.stdout is regex('PRETTY_NAME=.'~ bootstrap__search[item] | default(item) ~'.*')
+  become: "{{ bootstrap_become | default(omit) }}"
+  become_user: "{{ bootstrap_user }}"
 
 - name: set bootstrap facts (II)
   ansible.builtin.set_fact:
@@ -28,3 +30,5 @@
     label: "{{ item.key }}"
   when:
     - bootstrap_distribution in item.value
+  become: "{{ bootstrap_become | default(omit) }}"
+  become_user: "{{ bootstrap_user }}"

--- a/tasks/gather_facts.yml
+++ b/tasks/gather_facts.yml
@@ -20,7 +20,7 @@
     - bootstrap_distribution is not defined
     - bootstrap_facts.stdout is regex('PRETTY_NAME=.'~ bootstrap__search[item] | default(item) ~'.*')
   become: "{{ bootstrap_become | default(omit) }}"
-  become_user: "{{ bootstrap_user }}"
+  become_user: "{{ bootstrap_become_user }}"
 
 - name: set bootstrap facts (II)
   ansible.builtin.set_fact:
@@ -31,4 +31,4 @@
   when:
     - bootstrap_distribution in item.value
   become: "{{ bootstrap_become | default(omit) }}"
-  become_user: "{{ bootstrap_user }}"
+  become_user: "{{ bootstrap_become_user }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -12,7 +12,8 @@
     host: "{{ (ansible_ssh_host | default(ansible_host) | default(inventory_hostname)) }}"
     timeout: "{{ bootstrap_timeout }}"
   connection: local
-  become: false
+  become: "{{ bootstrap_become | default(omit) }}"
+  become_user: "{{ bootstrap_user }}"
   when:
     - ansible_connection is defined
     - ansible_connection not in [ "container", "docker", "community.docker.docker" ]
@@ -44,6 +45,8 @@
           bootstrap_os_family in [ "Debian", "RedHat", "Rocky", "Suse" ])
       vars:
         ansible_user: "{{ bootstrap_user }}"
+      become: "{{ bootstrap_become | default(omit) }}"
+      become_user: "{{ bootstrap_user }}"
 
     - name: set 'bootstrap_ansible_user' to value of 'ansible_user' (when wait_for_connection succeeded)
       ansible.builtin.set_fact:
@@ -69,5 +72,5 @@
         state: present
         update_cache: true
       loop: "{{ bootstrap__facts_packages.split() }}"
-  become: true
+  become: "{{ bootstrap_become | default(omit) }}"
   become_user: "{{ bootstrap_ansible_user | default(bootstrap_user) }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
     timeout: "{{ bootstrap_timeout }}"
   connection: local
   become: "{{ bootstrap_become | default(omit) }}"
-  become_user: "{{ bootstrap_user }}"
+  become_user: "{{ bootstrap_become_user }}"
   when:
     - ansible_connection is defined
     - ansible_connection not in [ "container", "docker", "community.docker.docker" ]
@@ -46,7 +46,7 @@
       vars:
         ansible_user: "{{ bootstrap_user }}"
       become: "{{ bootstrap_become | default(omit) }}"
-      become_user: "{{ bootstrap_user }}"
+      become_user: "{{ bootstrap_become_user }}"
 
     - name: set 'bootstrap_ansible_user' to value of 'ansible_user' (when wait_for_connection succeeded)
       ansible.builtin.set_fact:
@@ -55,9 +55,9 @@
         - bootstrap_connect is succeeded
         - ansible_user is defined
 
-    - name: set 'bootstrap_ansible_user' to value of 'bootstrap_user' (when wait_for_connection failed)
+    - name: set 'bootstrap_ansible_user' to value of 'bootstrap_become_user' (when wait_for_connection failed)
       ansible.builtin.set_fact:
-        bootstrap_ansible_user: "{{ bootstrap_user }}"
+        bootstrap_ansible_user: "{{ bootstrap_become_user }}"
       when:
         - bootstrap_connect is failed
 
@@ -73,4 +73,4 @@
         update_cache: true
       loop: "{{ bootstrap__facts_packages.split() }}"
   become: "{{ bootstrap_become | default(omit) }}"
-  become_user: "{{ bootstrap_ansible_user | default(bootstrap_user) }}"
+  become_user: "{{ bootstrap_ansible_user | default(bootstrap_become_user) }}"


### PR DESCRIPTION
Adapts this role to be able to be used in *all* use cases imagineable

Related:
https://github.com/robertdebock/ansible-role-bootstrap/issues/63
https://github.com/robertdebock/ansible-role-bootstrap/pull/64
https://github.com/robertdebock/ansible-role-bootstrap/issues/65
my yet-disclosed use case

<!-- Insert Description here, if any. -->

## **Required Checklist**

- [x] Documentation has been altered or extended appropriately
- [x] This pull request and its commits address only a single concern
- [x] I have followed [JonasPammer's Ansible Role Development Guidelines](https://github.com/JonasPammer/cookiecutter-ansible-role/blob/master/ROLE_DEVELOPMENT_GUIDELINES.adoc)
- [x] I am a nice guy <!-- the 'too long; did not read;' of the CODE_OF_CONDUCT.md -->

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)

Yes - changed default for variable.
For 2.0.0 behaviour, change `bootstrap_become` to `true`.

## _Optional_ Checklist

- [x] pre-commit was installed in local development environment (if not, a GitHub workflow will run pre-commit once you create the request)

- [ ] my commits are small, single-purpose, detailed and maybe even follow the [conventional commit specification](https://github.com/JonasPammer/JonasPammer/blob/master/demystifying/conventional_commits.adoc) for extra convenience of the reviewer
