### PR TITLE
ci: fix molecule CI (fedora35)

### DIFF
--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -15,7 +15,8 @@ platforms:
     image: "geerlingguy/docker-${MOLECULE_DISTRO:-debian10}-ansible:latest"
     command: ${MOLECULE_DOCKER_COMMAND:-""}
     volumes:
-      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+      - /sys/fs/cgroup:/sys/fs/cgroup:rw
+    cgroupns_mode: host
     privileged: true
     pre_build_image: true
 provisioner:


### PR DESCRIPTION
by using https://github.com/search?q=fedora35+user%3Ageerlingguy&type=code&ref=advsearch i found one geerlingguy repository with CI still passing and fedora35 being in the list of tested containers. it had the following difference which this commit replicates: https://github.com/geerlingguy/ansible-role-containerd/commit/07ced7cca8db589c6b2e031b687565c61ff951a7

i tested it in a tmate session and it worked using this change!
committing this now to a PR to see if it does damage to other distro's or if it's OK
(i am really not a docker or linux internals expert, still need to read my books i postponed for so long for advancing in networking-side career :))

Fixes #81

<!-- Insert Description here, if any. -->

## **Pull Request Checklist**

- [ ] I am a nice guy <!-- the 'too long; did not read;' of the CODE_OF_CONDUCT.md -->
- [x] This pull request and its commits address only a single concern
- [ ] Documentation has been altered or extended appropriately

- [ ] I have followed [JonasPammer's Ansible Role Development Guidelines](https://github.com/JonasPammer/cookiecutter-ansible-role/blob/master/ROLE_DEVELOPMENT_GUIDELINES.adoc)

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
