### PR TITLE
refactor: drop support for ansible-core 2.11 and 2.12

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,7 @@
     "ghcr.io/devcontainers/features/git-lfs:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/devcontainers/features/python:1": {
-      "version": "3.9"
+      "version": "3.12"
     }
   },
   // Use 'forwardPorts' to make a list of ports inside the container available locally.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ jobs:
       - name: set up python 3
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Install yamllint package.
         run: pip3 install "yamllint==1.*"
@@ -142,7 +142,7 @@ jobs:
       - name: set up python 3
         uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: setup/activate pre-commit cache
         uses: actions/cache@e12d46a63a90f2fae62d114769bbf2a179198b5c # v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,6 @@ jobs:
         run: tox
         env:
           TOX_SKIP_ENV: pre-commit
-          TOX_PARALLEL_NO_SPINNER: 1
           MOLECULE_DISTRO: ${{ matrix.distro }}
         if: github.event_name != 'workflow_dispatch'
 
@@ -166,7 +165,6 @@ jobs:
         env:
           TOXENV: py3-${{ github.event.inputs.ansible_version }}
           TOX_SKIP_ENV: pre-commit
-          TOX_PARALLEL_NO_SPINNER: 1
           MOLECULE_DESTROY: never
           MOLECULE_DISTRO: ${{ matrix.distro }}
         if: env.WORKFLOW_DISPATCH_IF == 'true'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,16 +31,15 @@ name: CI (Lint + Molecule)
         description: "Select Ansible Versions to run"
         required: false
         type: choice
+        # (minimum)
         default: "ansible-6"
         options:
-          - ansible-4,ansible-5,ansible-6,ansible-7,ansible-8
-          - ansible-4,ansible-5,ansible-6
-          - ansible-7,ansible-8
-          - ansible-4
-          - ansible-5
+          - ansible-6,ansible-7,ansible-8,ansible-9
+          - ansible-7,ansible-8,ansible-9
           - ansible-6
           - ansible-7
           - ansible-8
+          - ansible-9
   pull_request:
     branches-ignore:
       - renovate/**

--- a/DEVELOPMENT.adoc
+++ b/DEVELOPMENT.adoc
@@ -1,7 +1,7 @@
 [[development-system-dependencies]]
 === 📌 Development Machine Dependencies
 
-* Python 3.9 or greater
+* Python 3.10 or greater
 * Docker
 
 [[development-dependencies]]
@@ -96,9 +96,6 @@ $ *docker ps*
 $ *docker exec -it #30e9b8d59cdf# /bin/bash*
 
 root@instance-py3-ansible-2:/#
-root@instance-py3-ansible-2:/# python3 --version
-Python 3.8.10
-root@instance-py3-ansible-2:/# ...
 ----
 +
 [TIP]

--- a/DEVELOPMENT.adoc
+++ b/DEVELOPMENT.adoc
@@ -74,11 +74,11 @@ take a look at the matrix defined in link:.github/workflows/ci.yml[].
 $ *MOLECULE_DESTROY=never MOLECULE_DISTRO=#ubuntu1604# tox -e py3-ansible-#5#*
 ...
   TASK [ansible-role-pip : (redacted).] pass:[************************]
-  failed: [instance-py3-ansible-5] => changed=false
+  failed: [instance-py3-ansible-9] => changed=false
 ...
  pass:[___________________________________ summary ____________________________________]
   pre-commit: commands succeeded
-ERROR:   py3-ansible-5: commands failed
+ERROR:   py3-ansible-9: commands failed
 ----
 
 2. Find out the name of the molecule-provisioned docker container:
@@ -86,7 +86,7 @@ ERROR:   py3-ansible-5: commands failed
 [subs="quotes"]
 ----
 $ *docker ps*
-#30e9b8d59cdf#   geerlingguy/docker-debian10-ansible:latest   "/lib/systemd/systemd"   8 minutes ago   Up 8 minutes                                                                                                    instance-py3-ansible-5
+#30e9b8d59cdf#   geerlingguy/docker-debian10-ansible:latest   "/lib/systemd/systemd"   8 minutes ago   Up 8 minutes                                                                                                    instance-py3-ansible-9
 ----
 
 3. Get into a bash Shell of the container, and do your debugging:

--- a/README.md
+++ b/README.md
@@ -332,19 +332,19 @@ For a list of possible values fed to `MOLECULE_DISTRO`, take a look at the matri
 
 1.  Run your molecule tests with the option `MOLECULE_DESTROY=never`, e.g.:
 
-        $ MOLECULE_DESTROY=never MOLECULE_DISTRO=ubuntu1604 tox -e py3-ansible-5
+        $ MOLECULE_DESTROY=never MOLECULE_DISTRO=ubuntu1604 tox -e py3-ansible-9
         ...
           TASK [ansible-role-pip : (redacted).] ************************
-          failed: [instance-py3-ansible-5] => changed=false
+          failed: [instance-py3-ansible-9] => changed=false
         ...
          ___________________________________ summary ____________________________________
           pre-commit: commands succeeded
-        ERROR:   py3-ansible-5: commands failed
+        ERROR:   py3-ansible-9: commands failed
 
 2.  Find out the name of the molecule-provisioned docker container:
 
         $ docker ps
-        30e9b8d59cdf   geerlingguy/docker-debian10-ansible:latest   "/lib/systemd/systemd"   8 minutes ago   Up 8 minutes                                                                                                    instance-py3-ansible-5
+        30e9b8d59cdf   geerlingguy/docker-debian10-ansible:latest   "/lib/systemd/systemd"   8 minutes ago   Up 8 minutes                                                                                                    instance-py3-ansible-9
 
 3.  Get into a bash Shell of the container, and do your debugging:
 

--- a/README.orig.adoc
+++ b/README.orig.adoc
@@ -289,11 +289,10 @@ https://github.com/ansible-collections/community.general#tested-with-ansible[
 support pattern of Ansible's `community.general` collection].
 As of writing this is:
 
-* 2.11 (Ansible 4)
-* 2.12 (Ansible 5)
-* 2.13 (Ansible 6)
-* 2.14 (Ansible 7)
-* 2.15 (Ansible 8)
+* 2.13 (ansible-6)
+* 2.14 (ansible-7)
+* 2.15 (ansible-8)
+* 2.16 (ansible-9)
 
 
 [[development]]

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -7,7 +7,7 @@ galaxy_info:
   author: jonaspammer
   license: "MIT"
 
-  min_ansible_version: "2.9"
+  min_ansible_version: "2.13"
   platforms:
     # note: text after "actively tested: " represent the docker image name
     - name: EL # (Enterprise Linux)

--- a/tox.ini
+++ b/tox.ini
@@ -22,10 +22,10 @@ deps =
     ansible-6: ansible == 6.* # core 2.13
     ansible-7: ansible == 7.* # core 2.14
     ansible-8: ansible == 8.* # core 2.15
-    ansible-4: molecule == 4.*
-    ansible-!4: molecule >= 5 # molecule v5.0.0 requires ansible-core>=2.12
-    ansible-4: molecule-plugins[docker] == 22.*
-    ansible-!4: molecule-plugins[docker] >= 23 # molecule-plugins v23.4.0 requires ansible-core>=2.12
+    ansible-4: molecule == 4.* # molecule v5.0.0 requires ansible-core>=2.12
+    ansible-!4: molecule >= 5
+    ansible-4: molecule-plugins[docker] == 22.* # molecule-plugins v23.4.0 requires molecule v5 (ansible-core>=2.12)
+    ansible-!4: molecule-plugins[docker] >= 23
     paramiko == 3.*
     ansible-4: ansible-lint == 5.*
     ansible-!4: ansible-lint >= 6 # ansible-lint 6 made ansible 2.12+ a direct dependency

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,6 @@ skipsdist = true
 
 [testenv]
 passenv = *
-parallel_show_output = True
 deps =
     # For information on what included in the the "ansible" package, see
     # https://github.com/ansible-community/ansible-build-data/blob/main/ (e.g. `/9/ansible-9.build`).

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ extend-ignore = E203
 ### Ansible Testing through Molecule ###
 [tox]
 minversion = 4.1.2
-envlist = pre-commit,py{3}-ansible-{4,5,6,7,8}
+envlist = pre-commit,py{3}-ansible-{6,7,8,9}
 
 skipsdist = true
 
@@ -15,20 +15,16 @@ skipsdist = true
 passenv = *
 parallel_show_output = True
 deps =
-    # For information on what included in the the "ansible" package,
-    # see https://github.com/ansible-community/ansible-build-data/blob/main/ (e.g. `/5/ansible-5.build`).
-    ansible-4: ansible == 4.* # core 2.11
-    ansible-5: ansible == 5.* # core 2.12
+    # For information on what included in the the "ansible" package, see
+    # https://github.com/ansible-community/ansible-build-data/blob/main/ (e.g. `/9/ansible-9.build`).
     ansible-6: ansible == 6.* # core 2.13
     ansible-7: ansible == 7.* # core 2.14
     ansible-8: ansible == 8.* # core 2.15
-    ansible-4: molecule == 4.* # molecule v5.0.0 requires ansible-core>=2.12
-    ansible-!4: molecule
-    ansible-4: molecule-plugins[docker] == 22.* # molecule-plugins v23.4.0 requires molecule v5 (ansible-core>=2.12)
-    ansible-!4: molecule-plugins[docker]
+    ansible-9: ansible == 9.* # core 2.16
+    molecule == 6.*
+    molecule-plugins[docker] == 23.*
+    ansible-lint == 6.*
     paramiko == 3.*
-    ansible-4: ansible-lint == 5.*
-    ansible-!4: ansible-lint >= 6 # ansible-lint 6 made ansible 2.12+ a direct dependency
 commands =
     ansible --version
     molecule destroy

--- a/tox.ini
+++ b/tox.ini
@@ -23,9 +23,9 @@ deps =
     ansible-7: ansible == 7.* # core 2.14
     ansible-8: ansible == 8.* # core 2.15
     ansible-4: molecule == 4.* # molecule v5.0.0 requires ansible-core>=2.12
-    ansible-!4: molecule >= 5
+    ansible-!4: molecule
     ansible-4: molecule-plugins[docker] == 22.* # molecule-plugins v23.4.0 requires molecule v5 (ansible-core>=2.12)
-    ansible-!4: molecule-plugins[docker] >= 23
+    ansible-!4: molecule-plugins[docker]
     paramiko == 3.*
     ansible-4: ansible-lint == 5.*
     ansible-!4: ansible-lint >= 6 # ansible-lint 6 made ansible 2.12+ a direct dependency


### PR DESCRIPTION
last support drop was 2 years ago, in which i defined how i choose which versions to support:
https://github.com/JonasPammer/cookiecutter-ansible-role/issues/11