### PR TITLE
docs: highlight robertdebock's role and reason for this fork

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -21,6 +21,33 @@ This role also ensures an up-to-date package cache for most systems.
 In most cases, you will want to use this role in combination with my
 https://github.com/JonasPammer/ansible-role-core_dependencies[`core_dependencies`-role].
 
+[NOTE]
+.DISCLAIMER
+=====
+This role is a fork of https://github.com/robertdebock/ansible-role-bootstrap/releases/tag/5.2.12[robertdebock/ansible-role-bootstrap v5.2.12 (27 January, 2022)]
+(Apache License 2.0, Copyright Robert de Bock (robert@meinit.nl))
+with various changes/fixes. +
+Excerpt of changes from  https://github.com/JonasPammer/ansible-role-bootstrap/releases[/releases] below (with accompanying Issues in robertdebock's repository):
+
+* The role itself should pre-heat the the package manager cache:
+  https://github.com/robertdebock/ansible-role-bootstrap/pull/57[robertdebock/ansible-role-bootstrap#57]
+  ( fixed in
+  https://github.com/JonasPammer/ansible-role-bootstrap/pull/43[JonasPammer#43];
+  https://github.com/JonasPammer/ansible-role-bootstrap/pull/50[JonasPammer#50]
+  )
+* change default of become to `false`, add ability to define `become_user` seperately from `ansible_user`:
+  https://github.com/robertdebock/ansible-role-bootstrap/issues/63[robertdebock/ansible-role-bootstrap#63]
+  ( fixed in
+  https://github.com/JonasPammer/ansible-role-bootstrap/pull/61[JonasPammer#61]
+  )
+* change default of `bootstrap_become_user` to root
+* use `bootstrap_become_user` in ansible modules steps too
+* make role compatible with podman by specifying `/bin/sh`
+  https://github.com/robertdebock/ansible-role-bootstrap/pull/66[robertdebock/ansible-role-bootstrap#66]
+  ( fixed in
+  https://github.com/JonasPammer/ansible-role-bootstrap/pull/62[JonasPammer#62]
+  )
+=====
 
 toc::[]
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,21 @@ This role also ensures an up-to-date package cache for most systems.
 
 In most cases, you will want to use this role in combination with my [`core_dependencies`-role](https://github.com/JonasPammer/ansible-role-core_dependencies).
 
+DISCLAIMER
+
+This role is a fork of [robertdebock/ansible-role-bootstrap v5.2.12 (27 January, 2022)](https://github.com/robertdebock/ansible-role-bootstrap/releases/tag/5.2.12) (Apache License 2.0, Copyright Robert de Bock (<robert@meinit.nl>)) with various changes/fixes.  
+Excerpt of changes from [/releases](https://github.com/JonasPammer/ansible-role-bootstrap/releases) below (with accompanying Issues in robertdebock’s repository):
+
+-   The role itself should pre-heat the the package manager cache: [robertdebock/ansible-role-bootstrap#57](https://github.com/robertdebock/ansible-role-bootstrap/pull/57) ( fixed in [JonasPammer#43](https://github.com/JonasPammer/ansible-role-bootstrap/pull/43); [JonasPammer#50](https://github.com/JonasPammer/ansible-role-bootstrap/pull/50) )
+
+-   change default of become to `false`, add ability to define `become_user` seperately from `ansible_user`: [robertdebock/ansible-role-bootstrap#63](https://github.com/robertdebock/ansible-role-bootstrap/issues/63) ( fixed in [JonasPammer#61](https://github.com/JonasPammer/ansible-role-bootstrap/pull/61) )
+
+-   change default of `bootstrap_become_user` to root
+
+-   use `bootstrap_become_user` in ansible modules steps too
+
+-   make role compatible with podman by specifying `/bin/sh` [robertdebock/ansible-role-bootstrap#66](https://github.com/robertdebock/ansible-role-bootstrap/pull/66) ( fixed in [JonasPammer#62](https://github.com/JonasPammer/ansible-role-bootstrap/pull/62) )
+
 # 🔎 Metadata
 
 Below you can find information on…

--- a/README.orig.adoc
+++ b/README.orig.adoc
@@ -28,6 +28,33 @@ This role also ensures an up-to-date package cache for most systems.
 In most cases, you will want to use this role in combination with my
 https://github.com/JonasPammer/ansible-role-core_dependencies[`core_dependencies`-role].
 
+[NOTE]
+.DISCLAIMER
+=====
+This role is a fork of https://github.com/robertdebock/ansible-role-bootstrap/releases/tag/5.2.12[robertdebock/ansible-role-bootstrap v5.2.12 (27 January, 2022)]
+(Apache License 2.0, Copyright Robert de Bock (robert@meinit.nl))
+with various changes/fixes. +
+Excerpt of changes from  https://github.com/JonasPammer/ansible-role-bootstrap/releases[/releases] below (with accompanying Issues in robertdebock's repository):
+
+* The role itself should pre-heat the the package manager cache:
+  https://github.com/robertdebock/ansible-role-bootstrap/pull/57[robertdebock/ansible-role-bootstrap#57]
+  ( fixed in
+  https://github.com/JonasPammer/ansible-role-bootstrap/pull/43[JonasPammer#43];
+  https://github.com/JonasPammer/ansible-role-bootstrap/pull/50[JonasPammer#50]
+  )
+* change default of become to `false`, add ability to define `become_user` seperately from `ansible_user`:
+  https://github.com/robertdebock/ansible-role-bootstrap/issues/63[robertdebock/ansible-role-bootstrap#63]
+  ( fixed in
+  https://github.com/JonasPammer/ansible-role-bootstrap/pull/61[JonasPammer#61]
+  )
+* change default of `bootstrap_become_user` to root
+* use `bootstrap_become_user` in ansible modules steps too
+* make role compatible with podman by specifying `/bin/sh`
+  https://github.com/robertdebock/ansible-role-bootstrap/pull/66[robertdebock/ansible-role-bootstrap#66]
+  ( fixed in
+  https://github.com/JonasPammer/ansible-role-bootstrap/pull/62[JonasPammer#62]
+  )
+=====
 
 toc::[]
 


### PR DESCRIPTION
…right in introduction, with hyperlinks (including links directly to robertdebock's issues), not just unfortunately kind of 'hidden' in a text-include at end of a meta/ galaxy variable and in other page some may not visit

## **Pull Request Checklist**

- [x] I am a nice guy <!-- the 'too long; did not read;' of the CODE_OF_CONDUCT.md -->
- [x] This pull request and its commits address only a single concern
- [x] Documentation has been altered or extended appropriately

- [ ] I have followed [JonasPammer's Ansible Role Development Guidelines](https://github.com/JonasPammer/cookiecutter-ansible-role/blob/master/ROLE_DEVELOPMENT_GUIDELINES.adoc)

## Does this PR introduce a breaking change? (What changes might users need to make in their application due to this PR?)
